### PR TITLE
First Time Autochanged Page

### DIFF
--- a/infiniteviewpager/src/com/thehayro/view/InfiniteViewPager.java
+++ b/infiniteviewpager/src/com/thehayro/view/InfiniteViewPager.java
@@ -40,7 +40,7 @@ public class InfiniteViewPager extends ViewPager {
 
     private static final String TAG = "InfiniteViewPager";
 
-    private int mCurrPosition;
+    private int mCurrPosition = PAGE_POSITION_CENTER;
     private OnInfinitePageChangeListener mListener;
 
     public InfiniteViewPager(Context context) {


### PR DESCRIPTION
I believe that with this little initialization the little bug I told you, will be now solved.

The thing is that if you move a little bit the page it will go to onPageScrollStateChanged and since the program never enter before in onPageSelected, the mCurrPosition will never be initialized. So it will take the 0 as mCurrPosition and always go one left since PAGE_POSITION_LEFT is 0. Therefore, just initializing the variable to 1 at the beginning we will be sure that it comes back to the center page the first time if we don't really move to another one. Also you could put the line of code "setCurrentItem(PAGE_POSITION_CENTER, false);" on onPageScrollStateChanged, inside both left and right cases since in the other case we are already in the center. But this change is not necessary because is already working well :)

I hope my solution for this little bug is right and you can fix it.

One more time thanks for your library, it was really useful to me :)
